### PR TITLE
ci: Download artifact before build docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,10 @@ on:
         default: ${{ github.repository }}
         required: false
         type: string
+      artifact_name:
+        description: "Name of the artifact to be downloaded before"
+        required: false
+        type: string
       push:
         description: "Whether to push the image, or just build"
         required: true
@@ -26,7 +30,6 @@ on:
 
 jobs:
   docker:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,6 +44,12 @@ jobs:
 
       - name: Setup Docker buildx
         uses: famedly/setup-buildx-action@v2
+
+      - name: Download artifact
+        if: ${{ inputs.artifact_name != '' }}
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{inputs.artifact_name}}
 
       - name: Log into registry ${{ inputs.registry }}
         if: inputs.push


### PR DESCRIPTION
In our flutter and dart web build
jobs, we build the app in another
step and then build the docker
container.