### PR TITLE
chore(docker): use 16-core runners

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16core
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Needed so hopefully the workflow doesn't time out when compiling lots of Rust