### PR TITLE
fix(docker): revert configurable platforms

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,11 +23,6 @@ on:
         description: "Name of the artifact to be downloaded before"
         required: false
         type: string
-      platforms:
-        description: "Platforms to build for"
-        default: [linux/amd64, linux/arm64]
-        required: false
-        type: array
       push:
         description: "Whether to push the image, or just build"
         required: true
@@ -39,7 +34,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ inputs.platforms }}
+        platform:
+          - linux/amd64
+          - linux/arm64
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This reverts commit a6ce961a698afb5c506a1cc13ee76f6069ef4d07. Apparently github doesn't allow arrays in workflow inputs, so this isn't possible in this way right now.