### PR TITLE
feat(docker): include tags in digest artifact

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,6 +60,9 @@ jobs:
       contents: read
       packages: write
 
+    outputs:
+      tags: steps.meta.outputs.tags
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -114,7 +117,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v3
         with:
-          name: digests
+          name: digests-${{ inputs.registry }}-${{ inputs.image_name }}-${{ steps.meta.outputs.tags }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -129,7 +132,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v3
         with:
-          name: digests
+          name: digests-${{ inputs.registry }}-${{ inputs.image_name }}-${{ needs.docker.steps.meta.outputs.tags }}
           path: /tmp/digests
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
By including the tags in the name of the artifact, only the images with the same tag should end up being merged, and there should be no need to change the actual file/directory names in the tasks