### PR TITLE
chore: continue on build error

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,7 @@ jobs:
         run: cargo clippy
 
       - name: Build
+        continue-on-error: true
         run: |
           cargo auditable build --release --target x86_64-unknown-linux-musl
           sh -c "${{ steps.crate_metadata.outputs.binary_copies }}"


### PR DESCRIPTION
we still want clippy, fmt and check to run and pass if the build fails.

this is not a permanent solution :p

this was @jcgruenhage's idea