### PR TITLE
chore: bump gh actions to v4 because node dep

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @famedly/infrastructure @famedly/workflows @famedly/instant-messaging
+* @famedly/infrastructure @famedly/workflows @famedly/instant-messaging @famedly/matrix-team
 
 .github/workflows/ansible*.yml @famedly/infrastructure
 .github/workflows/docker.yml @famedly/infrastructure

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           path: "ansible_collections/${{ inputs.collection }}"

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           path: "ansible_collections/${{ inputs.collection }}"
@@ -65,7 +65,7 @@ jobs:
           ansible-test coverage xml
 
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ansible-test-${{ env.TESTING_PATH }}-${{ matrix.ansible_version }}-${{ matrix.python_version }}
           path: "ansible_collections/${{ inputs.collection }}/tests/output/"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           path: "ansible_collections/${{ inputs.collection }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,9 +68,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: linux/amd64
+          - platform: amd64
             runner: ${{ inputs.amd64_runner }}
-          - platform: linux/arm64
+          - platform: arm64
             runner: ${{ inputs.arm_runner }}
     runs-on: ${{ matrix.runner }}
     permissions:
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -92,7 +92,7 @@ jobs:
 
       - name: Download artifact
         if: ${{ inputs.artifact_name != '' }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{inputs.artifact_name}}
           path: ${{inputs.artifact_path}}
@@ -119,7 +119,7 @@ jobs:
           context: .
           push: ${{ inputs.push }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ matrix.platform }}
+          platforms: linux/${{ matrix.platform }}
           build-args: ${{ inputs.build_args }}
           file: ${{ inputs.file }}
           cache-from: type=gha
@@ -139,9 +139,9 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ inputs.registry }}-${{ inputs.image_name }}-${{ steps.tag.outputs.tags }}
+          name: digests-${{ inputs.registry }}-${{ inputs.image_name }}-${{ steps.tag.outputs.tags }}-${{ matrix.platform }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -154,10 +154,11 @@ jobs:
 
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: digests-${{ inputs.registry }}-${{ inputs.image_name }}-${{ needs.docker.outputs.tags }}
           path: /tmp/digests
+          pattern: digests-${{ inputs.registry }}-${{ inputs.image_name }}-${{ needs.docker.outputs.tags }}-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install additional dependencies
         if: inputs.extra_build_dependencies != ''


### PR DESCRIPTION
This will break your flows if you use @v3. td went ahead and bumped everything in frontend to v4 already so this is a quick hack for now. 

Setting to draft/wip until someone actually invests time in this migration.