### PR TITLE
Revert "chore(docker): use clean_registry in step `Create manifest li…

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -191,7 +191,7 @@ jobs:
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ steps.clean_registry.outputs.clean_registry }}/${{ inputs.image_name }}@sha256:%s ' *)
+            $(printf '${{ inputs.registry }}/${{ inputs.image_name }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |


### PR DESCRIPTION
…st and push`"

This reverts commit 81a6fa6cfce22bbc690855d0dd2d15e7afc25e52.